### PR TITLE
[Update] - diagnose utility update in response to hsd 22018737066.

### DIFF
--- a/common/source/util/diagnostic/main.cpp
+++ b/common/source/util/diagnostic/main.cpp
@@ -136,6 +136,23 @@ int scan_devices(const char *device_name) {
                     << "before running OneAPI programs using this device\n";
     }
 
+    if(handle == -1) {
+      if(!first_row_printed) {
+        o_list_stream << "\n";
+        o_list_stream << std::left << std::setw(20) << "Physical Dev Name"
+                    << std::left << std::setw(18) << "Status"
+                    << "Information\n";
+        first_row_printed = 1;
+      } 
+
+      o_list_stream << "\n";
+      o_list_stream << std::left << std::setw(20) << dev_name << std::left
+                    << std::setw(18) << "Uninitialized"
+                    << "PR slot function not configured\n"
+                    << std::left << std::setw(38) << " "
+                    << "Need to follow instructions to bind vfio-pci driver to PR slot function\n";
+    }
+
     // skip to next dev_name
     if (handle < 0) {
       continue;
@@ -362,9 +379,9 @@ int main(int argc, char *argv[]) {
   printf("Throughput = %.2f MB/s\n", (read_topspeed + write_topspeed) / 2);
 
   if (result)
-    printf("\nDIAGNOSTIC_PASSED\n");
+    printf("\n DIAGNOSTIC_PASSED\n");
   else
-    printf("\nDIAGNOSTIC_FAILED\n");
+    printf("\n DIAGNOSTIC_FAILED\n");
 
   acl_util_aligned_free(buf);
   acl_util_aligned_free(output);

--- a/common/source/util/diagnostic/main.cpp
+++ b/common/source/util/diagnostic/main.cpp
@@ -379,9 +379,9 @@ int main(int argc, char *argv[]) {
   printf("Throughput = %.2f MB/s\n", (read_topspeed + write_topspeed) / 2);
 
   if (result)
-    printf("\n DIAGNOSTIC_PASSED\n");
+    printf("\nDIAGNOSTIC_PASSED\n");
   else
-    printf("\n DIAGNOSTIC_FAILED\n");
+    printf("\nDIAGNOSTIC_FAILED\n");
 
   acl_util_aligned_free(buf);
   acl_util_aligned_free(output);


### PR DESCRIPTION
…comments in diagnose output when pr slot not initialized and attached to vfio-pci driver

*PR Title should start with one of the following tags: [Fix]/[Feature]/[Style]/[Update]*

*[Fix]- Bug Fix*

*[Feature]- for new feature*

*[Style]- Grammar or branding fix*

*[Update]-For an update to an existing feature*

------------- *Keep everything below this line* -------------------------

### Description
aocl diagnose is not showing enough information in cases where PR slot is not initialized and bound to a vfio-pci driver.
ICD diagnostics and BSP diagnostics are two separate and MMD diagnose code doesn't get any status update for ICD diagnostics which is run as part of aocl call 


### Collateral (docs, reports, design examples, case IDs):
 hsd 22018737066


- [ ] Document Update Required? (Specify FIM/AFU/Scripts)


### Tests added:
No new tests needed

### Tests run:
aocl diagnose, aocl program 

